### PR TITLE
Add sustainability page layout

### DIFF
--- a/sustainability/index.html
+++ b/sustainability/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sustainability</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@300;400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-pP1D1FJ0nuZVhImtr1cGukdxbYlR5c+3F4iAfDdc0AGJi/7luWGINuD/7++UZ5EKeosFVJeM3PcTUMflEOrheQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <canvas id="particles"></canvas>
+  <header class="site-header transparent">
+    <nav class="nav-bar">
+      <a href="#" class="logo">Rheingold</a>
+      <ul class="nav-links">
+        <li><a href="#">Home</a></li>
+        <li><a href="#">About</a></li>
+        <li><a href="#">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main>
+    <section class="hero parallax reveal" data-image="https://via.placeholder.com/1600x900">
+      <div class="container">
+        <h1>Sustainability</h1>
+        <p class="tagline">Placeholder for headline</p>
+        <button class="btn primary">Learn More</button>
+      </div>
+    </section>
+
+    <section class="mission reveal">
+      <div class="container">
+        <h2>Our Mission</h2>
+        <p>Placeholder text for mission statement.</p>
+        <div class="card-grid">
+          <div class="card hover-card">
+            <i class="fa-solid fa-leaf"></i>
+            <h3>Card Title</h3>
+            <p>Placeholder text.</p>
+          </div>
+          <div class="card hover-card">
+            <i class="fa-solid fa-recycle"></i>
+            <h3>Card Title</h3>
+            <p>Placeholder text.</p>
+          </div>
+          <div class="card hover-card">
+            <i class="fa-solid fa-water"></i>
+            <h3>Card Title</h3>
+            <p>Placeholder text.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="initiatives parallax" data-image="https://via.placeholder.com/1600x900">
+      <div class="container reveal">
+        <h2>Initiatives</h2>
+        <p>Placeholder text for initiatives.</p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <p>&copy; 2024 Rheingold</p>
+      <div class="social-links">
+        <a href="#" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+        <a href="#" aria-label="LinkedIn"><i class="fa-brands fa-linkedin"></i></a>
+        <a href="#" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/sustainability/script.js
+++ b/sustainability/script.js
@@ -1,0 +1,95 @@
+// Header transparency toggle
+const header = document.querySelector('.site-header');
+window.addEventListener('scroll', () => {
+  if (window.scrollY > 50) {
+    header.classList.remove('transparent');
+  } else {
+    header.classList.add('transparent');
+  }
+});
+
+// Scroll reveal
+const reveals = document.querySelectorAll('.reveal');
+const observer = new IntersectionObserver((entries) => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      entry.target.classList.add('active');
+      observer.unobserve(entry.target);
+    }
+  });
+}, { threshold: 0.1 });
+
+reveals.forEach(el => observer.observe(el));
+
+// Parallax backgrounds
+const parallaxSections = document.querySelectorAll('.parallax');
+parallaxSections.forEach(sec => {
+  const img = sec.getAttribute('data-image');
+  if (img) sec.style.backgroundImage = `url(${img})`;
+});
+
+window.addEventListener('scroll', () => {
+  parallaxSections.forEach(sec => {
+    const offset = window.pageYOffset;
+    sec.style.backgroundPositionY = offset * 0.5 + 'px';
+  });
+});
+
+// Button feedback
+const buttons = document.querySelectorAll('.btn');
+buttons.forEach(btn => {
+  btn.addEventListener('click', () => {
+    btn.classList.add('pressed');
+    setTimeout(() => btn.classList.remove('pressed'), 150);
+  });
+});
+
+// Light particle background
+const canvas = document.getElementById('particles');
+const ctx = canvas.getContext('2d');
+let particles = [];
+const numParticles = 60;
+
+function resizeCanvas() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+function initParticles() {
+  particles = [];
+  for (let i = 0; i < numParticles; i++) {
+    particles.push({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height,
+      r: Math.random() * 2 + 1,
+      dx: (Math.random() - 0.5) * 0.3,
+      dy: (Math.random() - 0.5) * 0.3
+    });
+  }
+}
+
+function drawParticles() {
+  ctx.clearRect(0,0,canvas.width,canvas.height);
+  ctx.fillStyle = 'rgba(255,255,255,0.7)';
+  particles.forEach(p => {
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, p.r, 0, Math.PI*2);
+    ctx.fill();
+    p.x += p.dx;
+    p.y += p.dy;
+    if (p.x < 0) p.x = canvas.width;
+    if (p.x > canvas.width) p.x = 0;
+    if (p.y < 0) p.y = canvas.height;
+    if (p.y > canvas.height) p.y = 0;
+  });
+  requestAnimationFrame(drawParticles);
+}
+
+window.addEventListener('resize', () => {
+  resizeCanvas();
+  initParticles();
+});
+
+resizeCanvas();
+initParticles();
+drawParticles();

--- a/sustainability/style.css
+++ b/sustainability/style.css
@@ -1,0 +1,180 @@
+:root {
+  --color-primary: #A88C4D;
+  --color-secondary: #F5F5F5;
+  --color-accent: #FFFFFF;
+  --max-width: 1200px;
+  --section-spacing: 80px;
+  font-family: 'Source Sans Pro', sans-serif;
+}
+
+body {
+  margin: 0;
+  font-family: 'Source Sans Pro', sans-serif;
+  background: var(--color-secondary);
+  color: #222;
+  overflow-x: hidden;
+}
+
+.container {
+  width: 90%;
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+/* Header */
+.site-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 1000;
+  padding: 20px 0;
+  transition: background 0.3s;
+  backdrop-filter: blur(10px);
+}
+.site-header.transparent {
+  background: transparent;
+}
+.site-header:not(.transparent) {
+  background: rgba(255,255,255,0.6);
+}
+
+.nav-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 90%;
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 20px;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-links a {
+  text-decoration: none;
+  color: #000;
+  font-weight: 600;
+  transition: opacity 0.3s;
+}
+
+.nav-links a:hover {
+  opacity: 0.7;
+}
+
+/* Sections */
+section {
+  padding: var(--section-spacing) 0;
+  position: relative;
+}
+
+.hero {
+  display: flex;
+  align-items: center;
+  text-align: center;
+  min-height: 100vh;
+  color: var(--color-accent);
+}
+
+.hero .tagline {
+  font-weight: 300;
+}
+
+.parallax {
+  background-attachment: fixed;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit,minmax(250px,1fr));
+  gap: 30px;
+  margin-top: 40px;
+}
+
+.card {
+  background: rgba(255,255,255,0.15);
+  border-radius: 12px;
+  padding: 30px;
+  backdrop-filter: blur(10px);
+  box-shadow: 0 4px 30px rgba(0,0,0,0.1);
+  text-align: center;
+  transition: transform 0.3s;
+}
+
+.card i {
+  font-size: 2rem;
+  color: var(--color-primary);
+  margin-bottom: 10px;
+}
+
+.hover-card:hover {
+  transform: translateY(-10px);
+}
+
+/* Buttons */
+.btn {
+  border: none;
+  padding: 12px 30px;
+  border-radius: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: filter 0.3s, opacity 0.3s;
+}
+
+.btn.primary {
+  background: var(--color-primary);
+  color: var(--color-accent);
+}
+
+.btn:hover {
+  filter: blur(1px);
+  opacity: 0.8;
+}
+.btn.pressed { transform: scale(0.95); }
+
+/* Scroll reveal */
+.reveal {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+.reveal.active {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Footer */
+.site-footer {
+  background: #1B1B1B;
+  color: var(--color-accent);
+  padding: 40px 0;
+  text-align: center;
+}
+
+.social-links a {
+  color: var(--color-accent);
+  margin: 0 10px;
+  transition: opacity 0.3s;
+}
+
+.social-links a:hover {
+  opacity: 0.7;
+}
+
+/* Particle canvas */
+#particles {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+}


### PR DESCRIPTION
## Summary
- add sustainability page with parallax hero and frosted-glass cards
- implement brand-compliant styles and interactive particle background

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894682fcc9083279270827ef84e5a44