### PR TITLE
style: redesign sustainability page

### DIFF
--- a/sustainability/index.html
+++ b/sustainability/index.html
@@ -11,8 +11,7 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <canvas id="particles"></canvas>
-  <header class="site-header transparent">
+  <header class="site-header">
     <nav class="nav-bar">
       <a href="#" class="logo">Rheingold</a>
       <button class="menu-toggle" aria-label="Menü">
@@ -27,44 +26,33 @@
   </header>
 
   <main>
-    <section class="hero parallax reveal" data-image="https://images.unsplash.com/photo-1520072959219-c595dc870360?auto=format&fit=crop&w=1600&q=80">
-      <div class="overlay"></div>
+    <section class="intro">
       <div class="container">
         <h1>Nachhaltigkeit</h1>
-        <p class="tagline">Verantwortung für morgen</p>
-        <button class="btn primary">Mehr erfahren</button>
+        <p class="subtitle">Verantwortung für morgen</p>
       </div>
     </section>
 
-    <section class="mission reveal">
+    <section class="principles">
       <div class="container">
-        <h2>Unsere Mission</h2>
-        <p>Wir setzen auf nachhaltige Prozesse und verantwortungsvollen Umgang mit Ressourcen.</p>
-        <div class="card-grid">
-          <div class="card hover-card">
+        <h2>Unsere Leitlinien</h2>
+        <div class="info-grid">
+          <div class="info-box">
             <i class="fa-solid fa-leaf"></i>
-            <h3>Recycelte Materialien</h3>
-            <p>Maximale Nutzung vorhandener Ressourcen.</p>
+            <h3>Ressourcenschonung</h3>
+            <p>Maximale Nutzung vorhandener Materialien.</p>
           </div>
-          <div class="card hover-card">
+          <div class="info-box">
             <i class="fa-solid fa-recycle"></i>
             <h3>Grüne Produktion</h3>
-            <p>Energieeffiziente und emissionsarme Herstellung.</p>
+            <p>Energieeffiziente und emissionsarme Prozesse.</p>
           </div>
-          <div class="card hover-card">
-            <i class="fa-solid fa-water"></i>
-            <h3>Schutz der Umwelt</h3>
+          <div class="info-box">
+            <i class="fa-solid fa-hand-holding-droplet"></i>
+            <h3>Umweltbewusstsein</h3>
             <p>Sorgsamer Umgang mit Wasser und Natur.</p>
           </div>
         </div>
-      </div>
-    </section>
-
-    <section class="initiatives parallax" data-image="https://images.unsplash.com/photo-1501004318641-b39e6451bec6?auto=format&fit=crop&w=1600&q=80">
-      <div class="overlay"></div>
-      <div class="container reveal">
-        <h2>Initiativen</h2>
-        <p>Unsere Projekte für eine nachhaltige Zukunft.</p>
       </div>
     </section>
   </main>

--- a/sustainability/script.js
+++ b/sustainability/script.js
@@ -1,4 +1,3 @@
-// Header transparency toggle
 const header = document.querySelector('.site-header');
 const navToggle = document.querySelector('.menu-toggle');
 const navLinks = document.querySelector('.nav-links');
@@ -9,94 +8,9 @@ navToggle.addEventListener('click', () => {
 
 window.addEventListener('scroll', () => {
   if (window.scrollY > 50) {
-    header.classList.remove('transparent');
+    header.classList.add('scrolled');
   } else {
-    header.classList.add('transparent');
+    header.classList.remove('scrolled');
   }
 });
 
-// Scroll reveal
-const reveals = document.querySelectorAll('.reveal');
-const observer = new IntersectionObserver((entries) => {
-  entries.forEach(entry => {
-    if (entry.isIntersecting) {
-      entry.target.classList.add('active');
-      observer.unobserve(entry.target);
-    }
-  });
-}, { threshold: 0.1 });
-
-reveals.forEach(el => observer.observe(el));
-
-// Parallax backgrounds
-const parallaxSections = document.querySelectorAll('.parallax');
-parallaxSections.forEach(sec => {
-  const img = sec.getAttribute('data-image');
-  if (img) sec.style.backgroundImage = `url(${img})`;
-});
-
-window.addEventListener('scroll', () => {
-  parallaxSections.forEach(sec => {
-    const offset = window.pageYOffset;
-    sec.style.backgroundPositionY = offset * 0.5 + 'px';
-  });
-});
-
-// Button feedback
-const buttons = document.querySelectorAll('.btn');
-buttons.forEach(btn => {
-  btn.addEventListener('click', () => {
-    btn.classList.add('pressed');
-    setTimeout(() => btn.classList.remove('pressed'), 150);
-  });
-});
-
-// Light particle background
-const canvas = document.getElementById('particles');
-const ctx = canvas.getContext('2d');
-let particles = [];
-const numParticles = 60;
-
-function resizeCanvas() {
-  canvas.width = window.innerWidth;
-  canvas.height = window.innerHeight;
-}
-
-function initParticles() {
-  particles = [];
-  for (let i = 0; i < numParticles; i++) {
-    particles.push({
-      x: Math.random() * canvas.width,
-      y: Math.random() * canvas.height,
-      r: Math.random() * 2 + 1,
-      dx: (Math.random() - 0.5) * 0.3,
-      dy: (Math.random() - 0.5) * 0.3
-    });
-  }
-}
-
-function drawParticles() {
-  ctx.clearRect(0,0,canvas.width,canvas.height);
-  ctx.fillStyle = 'rgba(255,255,255,0.7)';
-  particles.forEach(p => {
-    ctx.beginPath();
-    ctx.arc(p.x, p.y, p.r, 0, Math.PI*2);
-    ctx.fill();
-    p.x += p.dx;
-    p.y += p.dy;
-    if (p.x < 0) p.x = canvas.width;
-    if (p.x > canvas.width) p.x = 0;
-    if (p.y < 0) p.y = canvas.height;
-    if (p.y > canvas.height) p.y = 0;
-  });
-  requestAnimationFrame(drawParticles);
-}
-
-window.addEventListener('resize', () => {
-  resizeCanvas();
-  initParticles();
-});
-
-resizeCanvas();
-initParticles();
-drawParticles();

--- a/sustainability/style.css
+++ b/sustainability/style.css
@@ -1,23 +1,16 @@
-
 :root {
   --color-primary: #A88C4D;
   --color-secondary: #F5F5F5;
-  --color-accent: #FFFFFF;
   --color-dark: #1B1B1B;
   --max-width: 1200px;
-  --section-spacing: 80px;
   font-family: 'Source Sans Pro', sans-serif;
-}
-
-html {
-  scroll-behavior: smooth;
 }
 
 body {
   margin: 0;
   font-family: 'Source Sans Pro', sans-serif;
   background: var(--color-secondary);
-  color: #222;
+  color: var(--color-dark);
   overflow-x: hidden;
 }
 
@@ -34,15 +27,13 @@ body {
   left: 0;
   width: 100%;
   z-index: 1000;
-  padding: 20px 0;
-  transition: background 0.3s;
-  backdrop-filter: blur(10px);
+  padding: 15px 0;
+  background: rgba(255,255,255,0.9);
+  transition: box-shadow 0.3s;
 }
-.site-header.transparent {
-  background: transparent;
-}
-.site-header:not(.transparent) {
-  background: rgba(255,255,255,0.6);
+
+.site-header.scrolled {
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
 }
 
 .nav-bar {
@@ -110,131 +101,67 @@ body {
   }
 }
 
-/* Sections */
-section {
-  padding: var(--section-spacing) 0;
-  position: relative;
-}
-
-.hero {
-  display: flex;
-  align-items: center;
+/* Intro section */
+.intro {
+  background: linear-gradient(135deg, #f8f6f2, #fff);
   text-align: center;
-  min-height: 100vh;
-  color: var(--color-accent);
-  position: relative;
+  padding: 120px 0 80px;
 }
 
-.hero .tagline {
-  font-weight: 300;
+.intro h1 {
+  color: var(--color-primary);
+  font-size: 2.5rem;
+  margin: 0 0 10px;
 }
 
-.parallax {
-  background-attachment: fixed;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: cover;
-  position: relative;
+.intro .subtitle {
+  font-size: 1.2rem;
+  margin: 0;
 }
 
-.parallax .overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0,0,0,0.4);
-  z-index: 0;
+/* Principles */
+.principles {
+  padding: 80px 0;
 }
 
-.parallax .container {
-  position: relative;
-  z-index: 1;
-}
-
-.card-grid {
+.info-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit,minmax(250px,1fr));
   gap: 30px;
   margin-top: 40px;
 }
 
-.card {
-  background: rgba(255,255,255,0.15);
-  border-radius: 12px;
+.info-box {
+  background: #fff;
+  border-top: 4px solid var(--color-primary);
+  border-radius: 8px;
   padding: 30px;
-  backdrop-filter: blur(10px);
-  box-shadow: 0 4px 30px rgba(0,0,0,0.1);
   text-align: center;
-  transition: transform 0.3s;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
 }
 
-.card i {
+.info-box i {
   font-size: 2rem;
   color: var(--color-primary);
   margin-bottom: 10px;
 }
 
-.hover-card:hover {
-  transform: translateY(-10px);
-}
-
-/* Buttons */
-.btn {
-  border: none;
-  padding: 12px 30px;
-  border-radius: 12px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: filter 0.3s, opacity 0.3s;
-}
-
-.btn.primary {
-  background: var(--color-primary);
-  color: var(--color-accent);
-}
-
-.btn:hover {
-  filter: blur(1px);
-  opacity: 0.8;
-}
-.btn.pressed { transform: scale(0.95); }
-
-/* Scroll reveal */
-.reveal {
-  opacity: 0;
-  transform: translateY(20px);
-  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
-}
-.reveal.active {
-  opacity: 1;
-  transform: translateY(0);
-}
-
 /* Footer */
 .site-footer {
-  background: #1B1B1B;
-  color: var(--color-accent);
-  padding: 40px 0;
+  background: #fff;
   text-align: center;
+  padding: 40px 0;
+  margin-top: 40px;
 }
 
 .social-links a {
-  color: var(--color-accent);
+  color: var(--color-primary);
   margin: 0 10px;
-  transition: opacity 0.3s;
+  text-decoration: none;
+  font-size: 1.2rem;
 }
 
 .social-links a:hover {
   opacity: 0.7;
 }
 
-/* Particle canvas */
-#particles {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: -1;
-}


### PR DESCRIPTION
## Summary
- Simplify sustainability page layout and introduce hero intro and principles grid
- Rebuild styles with gold-accented theme inspired by pricing page
- Trim JS to basic navigation and header behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689477ba8f3c8327ba78df2d86a7654c